### PR TITLE
Implement: Feature #2 & #3 - Show everyone's debts

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -6,7 +6,7 @@ Presently Loan Wolf relies on a single basic model: the loan. However, this does
 
 == Installation
 
-Install, it, set up your db, and run this rake task to import loan quotes:
+Install it, set up your db, and run this rake task to import loan quotes:
 
   rake quotes:import
 

--- a/app/assets/javascripts/users.js.coffee
+++ b/app/assets/javascripts/users.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/

--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/loans_controller.rb
+++ b/app/controllers/loans_controller.rb
@@ -107,10 +107,4 @@ class LoansController < ApplicationController
   def listAll
   end
 
-  def optInShareDebtsPublicly
-  end
-
-  def optOutShareDebtsPublicly
-  end
-
 end

--- a/app/controllers/loans_controller.rb
+++ b/app/controllers/loans_controller.rb
@@ -6,9 +6,7 @@ class LoansController < ApplicationController
     @loans_as_debtor = current_user.debts.current
     @quote = Quote.offset(rand(Quote.count)).first
     @current_user = current_user
-    if current_user.opt_to_share_debt?
-      @total_debts_by_debtor = Loan.total_debts_by_debtor
-    end
+    @total_debts_by_debtor = Loan.total_debts_by_debtor
   end
   def newTo
   	@users = User.where('id != ?', current_user.id)

--- a/app/controllers/loans_controller.rb
+++ b/app/controllers/loans_controller.rb
@@ -5,6 +5,10 @@ class LoansController < ApplicationController
   	@loans_as_creditor = current_user.credits.current
     @loans_as_debtor = current_user.debts.current
     @quote = Quote.offset(rand(Quote.count)).first
+    @current_user = current_user
+    if current_user.opt_to_share_debt?
+      @total_debts_by_debtor = Loan.total_debts_by_debtor
+    end
   end
   def newTo
   	@users = User.where('id != ?', current_user.id)
@@ -102,4 +106,11 @@ class LoansController < ApplicationController
 
   def listAll
   end
+
+  def optInShareDebtsPublicly
+  end
+
+  def optOutShareDebtsPublicly
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,19 @@
+class UsersController < ApplicationController
+  before_filter :authenticate_user!
+
+  def optInShareDebtsPublicly
+    current_user.opt_to_share_debt = true
+    current_user.save :validate => false
+    respond_to do |format|
+      format.html { redirect_to '', notice: 'You are now sharing the amount you owe as a debtor publicly.'}
+    end
+  end
+
+  def optOutShareDebtsPublicly
+    current_user.opt_to_share_debt = false
+    current_user.save :validate => false
+    respond_to do |format|
+      format.html { redirect_to '', notice: 'The amount you owe as a debtor is now private.'}
+    end
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -5,7 +5,7 @@ class Loan < ActiveRecord::Base
   belongs_to :debtor, :class_name => 'User', :foreign_key => 'debtor_user_id'
   belongs_to :creditor, :class_name => 'User', :foreign_key => 'creditor_user_id'
 
-  validates :amount, numericality: { greater_than: 0, message: 'must be a legitimate dollar value greater than $0' }
+  validates :amount, numericality: { greater_than: 0, message: 'must be a legitimate dollar value greater than $0'}
 
   scope :current, where(:is_archived => nil)
 
@@ -15,4 +15,9 @@ class Loan < ActiveRecord::Base
   def can_be_marked_approved_by?(user)
   	user == debtor
   end
+
+  def total_debts_by_debtor
+    self.group(:debtor).select("debtor, SUM(*) as sum")
+  end
+
 end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -7,6 +7,7 @@ class Loan < ActiveRecord::Base
 
   validates :amount, numericality: { greater_than: 0, message: 'must be a legitimate dollar value greater than $0'}
 
+  # Bug? Should check for approval status as well
   scope :current, where(:is_archived => nil)
 
   def can_be_marked_paid_by?(user)
@@ -19,6 +20,7 @@ class Loan < ActiveRecord::Base
   def self.total_debts_by_debtor
     self.joins(:debtor)
       .where('users.opt_to_share_debt' => true)
+      .where("approved_date IS NOT NULL")
       .where(:is_archived => nil)
       .group(:debtor_user_id)
       .select("debtor_user_id, SUM(amount) as sum")

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -19,6 +19,7 @@ class Loan < ActiveRecord::Base
   def self.total_debts_by_debtor
     self.joins(:debtor)
       .where('users.opt_to_share_debt' => true)
+      .where(:is_archived => nil)
       .group(:debtor_user_id)
       .select("debtor_user_id, SUM(amount) as sum")
   end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -16,8 +16,8 @@ class Loan < ActiveRecord::Base
   	user == debtor
   end
 
-  def total_debts_by_debtor
-    self.group(:debtor).select("debtor, SUM(*) as sum")
+  def self.total_debts_by_debtor
+    self.group(:debtor_user_id).select("debtor_user_id, SUM(amount) as sum")
   end
 
 end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -17,7 +17,10 @@ class Loan < ActiveRecord::Base
   end
 
   def self.total_debts_by_debtor
-    self.group(:debtor_user_id).select("debtor_user_id, SUM(amount) as sum")
+    self.joins(:debtor)
+      .where('users.opt_to_share_debt' => true)
+      .group(:debtor_user_id)
+      .select("debtor_user_id, SUM(amount) as sum")
   end
 
 end

--- a/app/views/loans/index.html.erb
+++ b/app/views/loans/index.html.erb
@@ -8,9 +8,9 @@
 <h3>The Wolf Bites You <small>(money you owe)</small></h3>
 
 <% if @current_user.opt_to_share_debt? %>
-    <%= link_to raw('Share my debts publicly <i class="icon-remove"></i>'), optOutShareDebtsPublicly_url(), :class => 'btn btn-danger',  :method => :put, :confirm => 'Please confirm that you keep the amount you owe as a debtor private.' %>
+    <%= link_to raw('Stop sharing my debts publicly <i class="icon-remove"></i>'), optOutShareDebtsPublicly_url(), :class => 'btn btn-danger',  :method => :put, :confirm => 'Please confirm that you want to keep the amount you owe as a debtor private.' %>
 <% else %>                                                                                                                               
-    <%= link_to raw('Share my debts publicly <i class="icon-ok"></i>'),     optInShareDebtsPublicly_url(),  :class => 'btn btn-success', :method => :put, :confirm => 'Please confirm that you make the amount you owe as a debtor public.' %>
+    <%= link_to raw('Start sharing my debts publicly <i class="icon-ok"></i>'),    optInShareDebtsPublicly_url(),  :class => 'btn btn-success', :method => :put, :confirm => 'Please confirm that you want to make the amount you owe as a debtor public.' %>
 <% end %>
 
 <% if @loans_as_debtor.any? %>

--- a/app/views/loans/index.html.erb
+++ b/app/views/loans/index.html.erb
@@ -8,9 +8,9 @@
 <h3>The Wolf Bites You <small>(money you owe)</small></h3>
 
 <% if @current_user.opt_to_share_debt? %>
-<%= link_to raw('Share my debts publicly' <i class="icon-remove"></i>'), optOutShareDebtsPublicly_url(), :class => 'btn btn-danger', :confirm => 'Please confirm that you keep the amount you owe as a debtor private.' %>
-<% else $>
-<%= link_to raw('Share my debts publicly' <i class="icon-ok"></i>'), optInShareDebtsPublicly_url(), :class => 'btn btn-success', :confirm => 'Please confirm that you make the amount you owe as a debtor public.' %>
+    <%= link_to raw('Share my debts publicly <i class="icon-remove"></i>'), optOutShareDebtsPublicly_url(), :class => 'btn btn-danger',  :confirm => 'Please confirm that you keep the amount you owe as a debtor private.' %>
+<% else %>                                                                                                                               
+    <%= link_to raw('Share my debts publicly <i class="icon-ok"></i>'),     optInShareDebtsPublicly_url(),  :class => 'btn btn-success', :confirm => 'Please confirm that you make the amount you owe as a debtor public.' %>
 <% end %>
 
 <% if @loans_as_debtor.any? %>
@@ -93,3 +93,4 @@
 <% end %>
 
 <% if @loans_as_debtor.any? %>
+<% end %>

--- a/app/views/loans/index.html.erb
+++ b/app/views/loans/index.html.erb
@@ -7,6 +7,12 @@
 <hr />
 <h3>The Wolf Bites You <small>(money you owe)</small></h3>
 
+<% if @current_user.opt_to_share_debt? %>
+<%= link_to raw('Share my debts publicly' <i class="icon-remove"></i>'), optOutShareDebtsPublicly_url(), :class => 'btn btn-danger', :confirm => 'Please confirm that you keep the amount you owe as a debtor private.' %>
+<% else $>
+<%= link_to raw('Share my debts publicly' <i class="icon-ok"></i>'), optInShareDebtsPublicly_url(), :class => 'btn btn-success', :confirm => 'Please confirm that you make the amount you owe as a debtor public.' %>
+<% end %>
+
 <% if @loans_as_debtor.any? %>
 	<table class="table table-bordered table-striped table-hover">
 	  <tr>
@@ -85,3 +91,5 @@
 <% else %>
   <p>No one owes you anything!</p>
 <% end %>
+
+<% if @loans_as_debtor.any? %>

--- a/app/views/loans/index.html.erb
+++ b/app/views/loans/index.html.erb
@@ -92,5 +92,24 @@
   <p>No one owes you anything!</p>
 <% end %>
 
-<% if @loans_as_debtor.any? %>
+<% if @total_debts_by_debtor.any? %>
+    <hr />
+    <h3>Biggest Wolf Bites <small>(Most money owed)</small></h3>
+    <table class="table table-bordered table-striped table-hover">
+        <thead>
+	    <tr>
+	        <th>Debtor</th>
+	        <th style="text-align:right; padding-right:1em">Amount owed</th>
+	    </tr>
+        </thead>
+        <tbody>
+            <% @total_debts_by_debtor.each do |debtor| %>
+                <tr>
+                    <td><%= debtor.debtor %></td>
+                    <td><%= debtor.sum%></td>
+                </tr>
+                
+            <% end %>
+        </tbody>
+    </table>
 <% end %>

--- a/app/views/loans/index.html.erb
+++ b/app/views/loans/index.html.erb
@@ -8,9 +8,9 @@
 <h3>The Wolf Bites You <small>(money you owe)</small></h3>
 
 <% if @current_user.opt_to_share_debt? %>
-    <%= link_to raw('Share my debts publicly <i class="icon-remove"></i>'), optOutShareDebtsPublicly_url(), :class => 'btn btn-danger',  :confirm => 'Please confirm that you keep the amount you owe as a debtor private.' %>
+    <%= link_to raw('Share my debts publicly <i class="icon-remove"></i>'), optOutShareDebtsPublicly_url(), :class => 'btn btn-danger',  :method => :put, :confirm => 'Please confirm that you keep the amount you owe as a debtor private.' %>
 <% else %>                                                                                                                               
-    <%= link_to raw('Share my debts publicly <i class="icon-ok"></i>'),     optInShareDebtsPublicly_url(),  :class => 'btn btn-success', :confirm => 'Please confirm that you make the amount you owe as a debtor public.' %>
+    <%= link_to raw('Share my debts publicly <i class="icon-ok"></i>'),     optInShareDebtsPublicly_url(),  :class => 'btn btn-success', :method => :put, :confirm => 'Please confirm that you make the amount you owe as a debtor public.' %>
 <% end %>
 
 <% if @loans_as_debtor.any? %>

--- a/app/views/loans/index.html.erb
+++ b/app/views/loans/index.html.erb
@@ -7,12 +7,6 @@
 <hr />
 <h3>The Wolf Bites You <small>(money you owe)</small></h3>
 
-<% if @current_user.opt_to_share_debt? %>
-    <%= link_to raw('Stop sharing my debts publicly <i class="icon-remove"></i>'), optOutShareDebtsPublicly_url(), :class => 'btn btn-danger',  :method => :put, :confirm => 'Please confirm that you want to keep the amount you owe as a debtor private.' %>
-<% else %>                                                                                                                               
-    <%= link_to raw('Start sharing my debts publicly <i class="icon-ok"></i>'),    optInShareDebtsPublicly_url(),  :class => 'btn btn-success', :method => :put, :confirm => 'Please confirm that you want to make the amount you owe as a debtor public.' %>
-<% end %>
-
 <% if @loans_as_debtor.any? %>
 	<table class="table table-bordered table-striped table-hover">
 	  <tr>
@@ -92,24 +86,31 @@
   <p>No one owes you anything!</p>
 <% end %>
 
-<% if @total_debts_by_debtor.any? %>
-    <hr />
-    <h3>Biggest Wolf Bites <small>(Most money owed)</small></h3>
-    <table class="table table-bordered table-striped table-hover">
-        <thead>
-	    <tr>
-	        <th>Debtor</th>
-	        <th style="text-align:right; padding-right:1em">Amount owed</th>
-	    </tr>
-        </thead>
-        <tbody>
-            <% @total_debts_by_debtor.each do |debtor| %>
-                <tr>
-                    <td><%= debtor.debtor %></td>
-                    <td><%= debtor.sum%></td>
-                </tr>
-                
-            <% end %>
-        </tbody>
-    </table>
+<hr />
+<h3>Biggest Wolf Bites <small>(Most money owed)</small></h3>
+<% if @current_user.opt_to_share_debt? %>
+    <% if @total_debts_by_debtor.any? %>
+        <table class="table table-bordered table-striped table-hover">
+            <thead>
+	        <tr>
+	            <th>Debtor</th>
+	            <th style="text-align:right; padding-right:1em">Amount owed</th>
+	        </tr>
+            </thead>
+            <tbody>
+                <% @total_debts_by_debtor.each do |debtor| %>
+                    <tr>
+                        <td><%= debtor.debtor %></td>
+                        <td style="text-align:right; padding-right:1em">
+                            <%= number_to_currency debtor.sum%>
+                        </td>
+                    </tr>
+                    
+                <% end %>
+            </tbody>
+        </table>
+    <% end %>
+    <%= link_to raw('Stop sharing my debts publicly <i class="icon-remove"></i>'), optOutShareDebtsPublicly_url(), :class => 'btn btn-danger',  :method => :put, :confirm => 'Please confirm that you want to keep the amount you owe as a debtor private.' %>
+<% else %>                                                                                                                               
+    <%= link_to raw('Start sharing my debts publicly <i class="icon-ok"></i>'),    optInShareDebtsPublicly_url(),  :class => 'btn btn-success', :method => :put, :confirm => 'Please confirm that you want to make the amount you owe as a debtor public.' %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,10 @@ Slate2::Application.routes.draw do
 
   get "loans/:id/sendPaymentReminder" => 'loans#sendPaymentReminder', :as => :sendPaymentReminder
 
+  put "users/optOutShareDebtsPublicly" => 'users#optOutShareDebtsPublicly', :as => :optOutShareDebtsPublicly
+
+  put "users/optInShareDebtsPublicly" => 'users#optInShareDebtsPublicly', :as => :optInShareDebtsPublicly
+
   devise_for :users
 
   # The priority is based upon order of creation:

--- a/db/migrate/20160228221556_add_opt_in_to_publicly_display_debt_to_users.rb
+++ b/db/migrate/20160228221556_add_opt_in_to_publicly_display_debt_to_users.rb
@@ -1,0 +1,5 @@
+class AddOptInToPubliclyDisplayDebtToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :opt_to_share_debt, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121209195645) do
+ActiveRecord::Schema.define(:version => 20160228221556) do
 
   create_table "loans", :force => true do |t|
     t.integer  "debtor_user_id"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(:version => 20121209195645) do
     t.datetime "created_at",                             :null => false
     t.datetime "updated_at",                             :null => false
     t.string   "initials"
+    t.boolean  "opt_to_share_debt"
   end
 
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/unit/helpers/users_helper_test.rb
+++ b/test/unit/helpers/users_helper_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class UsersHelperTest < ActionView::TestCase
+end


### PR DESCRIPTION
Description
-----------

Added a feature implementing requests #2 and #3 whereby users can opt-in to show total amount owed as debtor. This simply produces a table of user initials and total amount owed. The totals are not itemized by lender and only includes loans which have been accepted by the borrower to prevent lenders from hacking the totals.

Users who do not opt-in to share their total debts see only a button to opt-in. Similarly, one can opt-out at any time with the same button.

Notes
-----

I don't have access to the Chef provision files, so I had to guess a bit about Ruby, Rails, and gem versions. I think I got the right combination because everything is running well.

I had to add a User controller to handle toggling of the `opt_to_share_debts` flag.

Also, I have tested this manually (see the various fixes in the commit log), but I haven't learned how to set up tests in Rails yet. This was my first time using Rails (and Ruby), so I'll work on that later if needed.